### PR TITLE
Stop writing to nonexisting temp file

### DIFF
--- a/scm/GitManager.go
+++ b/scm/GitManager.go
@@ -70,7 +70,8 @@ func (a GitManager) Commit(dir bugs.Directory, commitMsg string) error {
 	}
 	file, err := ioutil.TempFile("", "bugCommit")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not create file for commit message.\n")
+		fmt.Fprintf(os.Stderr, "Could not create temporary file.\nNothing commited.\n")
+		return err
 	}
 	defer func() {
 		os.Remove(file.Name())


### PR DESCRIPTION
We should early return when /tmp folder is not accessible.