### PR TITLE
Add information about new/closed/updated issues to commit msg in git

### DIFF
--- a/bugapp/Commit.go
+++ b/bugapp/Commit.go
@@ -13,6 +13,7 @@ func Commit(args ArgumentList) {
 	} else {
 		options["autoclose"] = false
 	}
+	options["use_bug_prefix"] = true // SCM will ignore this option if it doesn't know it
 
 	scm, _, err := scm.DetectSCM(options)
 	if err != nil {

--- a/scm/Detect.go
+++ b/scm/Detect.go
@@ -38,10 +38,14 @@ func DetectSCM(options map[string]bool) (SCMHandler, bugs.Directory, error) {
 
 	dirFound, scmtype := walkAndSearch(wd, []string{".git", ".hg"})
 	if dirFound != "" && scmtype == ".git" {
-		if val, exists := options["autoclose"]; exists && val == true {
-			return GitManager{Autoclose: true}, bugs.Directory(dirFound), nil
+		var gm GitManager
+		if val, ok := options["autoclose"]; ok {
+			gm.Autoclose = val
 		}
-		return GitManager{Autoclose: false}, bugs.Directory(dirFound), nil
+		if val, ok := options["use_bug_prefix"]; ok {
+			gm.UseBugPrefix = val
+		}
+		return gm, bugs.Directory(dirFound), nil
 	}
 	if dirFound != "" && scmtype == ".hg" {
 		return HgManager{}, bugs.Directory(dirFound), nil

--- a/scm/GitManager.go
+++ b/scm/GitManager.go
@@ -1,6 +1,7 @@
 package scm
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/driusan/bug/bugs"
 	"io/ioutil"
@@ -23,30 +24,142 @@ func (a GitManager) Purge(dir bugs.Directory) error {
 	return cmd.Run()
 }
 
-func (a GitManager) closedGithubIssues(dir bugs.Directory) []string {
+type issueStatus struct {
+	a, d, m bool // Added, Deleted, Modified
+}
+type issuesStatus map[string]issueStatus
+
+// Get list of created, updated, closed and closed-on-github issues.
+//
+// In general following rules to categorize issues are applied:
+// * closed if Description file is deleted (D);
+// * created if Description file is created (A) (TODO: handle issue renamings);
+// * closed issue will also close issue on GH when Autoclose is true (see Identifier example);
+// * updated if Description file is modified (M);
+// * updated if Description is unchanged but any other files are touched. (' '+x)
+//
+// eg output from `from git status --porcelain`, appendix mine
+// note that `git add -A issues` was invoked before
+//
+// D  issues/First-GH-issue/Description		issue closed (GH issues are also here)
+// D  issues/First-GH-issue/Identifier		maybe it is GH issue, maybe not
+// M  issues/issue--2/Description		desc updated
+// A  issues/issue--2/Status			new field added (status); considered as update unless Description is also created
+// D  issues/issue1/Description			issue closed
+// A  issues/issue3/Description			new issue, description field is mandatory for rich format
+func (a GitManager) currentStatus(dir bugs.Directory) (closedOnGitHub []string, _ issuesStatus) {
 	ghRegex := regexp.MustCompile("(?im)^-Github:(.*)$")
+	closesGH := func(file string) (issue string, ok bool) {
+		if !a.Autoclose {
+			return "", false
+		}
+		if !strings.HasSuffix(file, "Identifier") {
+			return "", false
+		}
+		diff := exec.Command("git", "diff", "--staged", "--", file)
+		diffout, _ := diff.CombinedOutput()
+		matches := ghRegex.FindStringSubmatch(string(diffout))
+		if len(matches) > 1 {
+			return strings.TrimSpace(matches[1]), true
+		}
+		return "", false
+	}
+	short := func(path string) string {
+		b := strings.Index(path, "/")
+		e := strings.LastIndex(path, "/")
+		if b+1 >= e {
+			return "???"
+		}
+		return path[b+1 : e]
+	}
+
 	cmd := exec.Command("git", "status", "-z", "--porcelain", string(dir))
 	out, _ := cmd.CombinedOutput()
 	files := strings.Split(string(out), "\000")
-	var retVal []string
+
+	issues := issuesStatus{}
+	var ghClosed []string
+	const minLineLen = 3 /*for path*/ + 2 /*for issues dir with path sep*/ + 3 /*for issue name, path sep and any file under issue dir*/
 	for _, file := range files {
-		if file == "" {
+		if len(file) < minLineLen {
 			continue
 		}
 
-		if file[:1] == "D" && strings.HasSuffix(file, "Identifier") {
-			diff := exec.Command("git", "diff", "--staged", "--", file[3:])
-			diffout, _ := diff.CombinedOutput()
-			//fmt.Printf("Output: %s", diffout)
-			if matches := ghRegex.FindStringSubmatch(string(diffout)); len(matches) > 1 {
-				retVal = append(retVal, strings.TrimSpace(matches[1]))
+		// TODO: check if path starts with $issues
+		path := file[3:]
+		op := file[0]
+		desc := strings.HasSuffix(path, "/Description")
+		name := short(path)
+		issue := issues[name]
+
+		switch {
+		case desc && op == 'D':
+			issue.d = true
+		case desc && op == 'A':
+			issue.a = true
+		default:
+			issue.m = true
+			if op == 'D' {
+				if ghIssue, ok := closesGH(path); ok {
+					ghClosed = append(ghClosed, ghIssue)
+					issue.d = true // to be sure
+				}
 			}
 		}
+
+		issues[name] = issue
 	}
-	return retVal
+	return ghClosed, issues
 }
 
-func (a GitManager) Commit(dir bugs.Directory, commitMsg string) error {
+// Create commit message by iterate over issues in order:
+// closed issues are most important (something is DONE, ok? ;), those issues will also become hidden)
+// new issues are next, with just updates at the end
+// TODO: do something if this message will be too long
+func (a GitManager) commitMsg(dir bugs.Directory) []byte {
+	ghClosed, issues := a.currentStatus(dir)
+
+	done, add, update, together := &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{}
+	var cntd, cnta, cntu int
+
+	for issue, state := range issues {
+		if state.d {
+			fmt.Fprintf(done, ", %q", issue)
+			cntd++
+		} else if state.a {
+			fmt.Fprintf(add, ", %q", issue)
+			cnta++
+		} else if state.m {
+			fmt.Fprintf(update, ", %q", issue)
+			cntu++
+		}
+	}
+
+	f := func(b *bytes.Buffer, what string, many bool) {
+		if b.Len() == 0 {
+			return
+		}
+		var m string
+		if many {
+			m = "s:"
+		}
+		s := b.Bytes()[2:]
+		fmt.Fprintf(together, "%s issue%s %s; ", what, m, s)
+	}
+	f(done, "Close", cntd > 1)
+	f(add, "Create", cnta > 1)
+	f(update, "Update", cntu > 1)
+	if l := together.Len(); l > 0 {
+		together.Truncate(l - 2) // "; " from last applied f()
+	}
+
+	if len(ghClosed) > 0 {
+		fmt.Fprintf(together, "\n\nCloses %s\n", strings.Join(ghClosed, ", closes "))
+	}
+	return together.Bytes()
+}
+
+func (a GitManager) Commit(dir bugs.Directory, backupCommitMsg string) error {
 	cmd := exec.Command("git", "add", "-A", string(dir))
 	if err := cmd.Run(); err != nil {
 		fmt.Printf("Could not add issues to be commited: %s?\n", err.Error())
@@ -54,12 +167,9 @@ func (a GitManager) Commit(dir bugs.Directory, commitMsg string) error {
 
 	}
 
-	var closesGH string
-	if a.Autoclose {
-		ci := a.closedGithubIssues(dir)
-		if len(ci) > 0 {
-			closesGH = fmt.Sprintf("\nCloses %s\n", strings.Join(ci, ", closes "))
-		}
+	msg := a.commitMsg(dir)
+	if len(msg) == 0 {
+		msg = []byte(backupCommitMsg)
 	}
 
 	file, err := ioutil.TempFile("", "bugCommit")
@@ -68,7 +178,7 @@ func (a GitManager) Commit(dir bugs.Directory, commitMsg string) error {
 	}
 	defer os.Remove(file.Name())
 
-	fmt.Fprintf(file, "%s\n%s", commitMsg, closesGH)
+	fmt.Fprintf(file, "%s\n", msg)
 	cmd = exec.Command("git", "commit", "-o", string(dir), "-F", file.Name(), "-q")
 	if err := cmd.Run(); err != nil {
 		// If nothing was added commit will have an error,

--- a/scm/GitManager_test.go
+++ b/scm/GitManager_test.go
@@ -195,10 +195,11 @@ func TestGitManagerAutoclosingGitHub(t *testing.T) {
 	if msg, err := commits[1].(GitCommit).CommitMessage(); err != nil {
 		t.Error("Error getting git logs while attempting to test GitHub autoclosing")
 	} else {
-		if msg != `Removal commit
-
-Closes #Whitespace, closes #TestBug
-` {
+		closing := func(issue string) bool {
+			return strings.Contains(msg, "Closes #"+issue) ||
+				strings.Contains(msg, ", closes #"+issue)
+		}
+		if !closing("Whitespace") || !closing("TestBug") {
 			fmt.Printf("%s\n", msg)
 			t.Error("GitManager did not autoclose Github issues")
 		}

--- a/scm/TestHelpers_test.go
+++ b/scm/TestHelpers_test.go
@@ -33,7 +33,7 @@ func runCmd(cmd string, options ...string) (string, error) {
 	return string(out), err
 }
 
-func assertLogs(tester ManagerTester, t *testing.T, titles []string, diffs []string) {
+func assertLogs(tester ManagerTester, t *testing.T, titles []map[string]bool, diffs []string) {
 	logs, err := tester.GetLogs()
 	if err != nil {
 		t.Error("Could not get scm logs" + err.Error())
@@ -50,7 +50,7 @@ func assertLogs(tester ManagerTester, t *testing.T, titles []string, diffs []str
 	}
 
 	for i, _ := range titles {
-		if titles[i] != logs[i].LogMsg() {
+		if _, ok := titles[i][logs[i].LogMsg()]; !ok {
 			t.Error("Unexpected commit message:" + logs[i].LogMsg())
 		}
 
@@ -58,7 +58,14 @@ func assertLogs(tester ManagerTester, t *testing.T, titles []string, diffs []str
 			t.Error("Could not get diff of commit")
 		} else {
 			if diff != diffs[i] {
-				t.Error("Incorrect diff for " + titles[i])
+				// get shortest commit msg to keep errors simple
+				var s string
+				for k := range titles[i] {
+					if len(s) == 0 || len(k) < len(s) {
+						s = k
+					}
+				}
+				t.Error(fmt.Sprintf("Incorrect diff for i=%d, title=%s", i, s))
 				fmt.Fprintf(os.Stderr, "Got %s, expected %s", diff, diffs[i])
 			}
 		}
@@ -86,7 +93,14 @@ func runtestRenameCommitsHelper(tester ManagerTester, t *testing.T, expectedDiff
 
 	tester.AssertCleanTree(t)
 
-	assertLogs(tester, t, []string{"Initial commit", "This is a test rename"}, expectedDiffs)
+	assertLogs(tester, t, []map[string]bool{{
+		"Initial commit":          true, // simple format
+		`Create issue "Test-bug"`: true, // rich format
+	}, {
+		"This is a test rename":                    true, // simple format
+		`Update issues: "Test-bug", "Renamed-bug"`: true, // rich format
+		`Update issues: "Renamed-bug", "Test-bug"`: true, // has two alternatives equally good
+	}}, expectedDiffs)
 
 }
 func runtestCommitDirtyTree(tester ManagerTester, t *testing.T) {


### PR DESCRIPTION
Instead of always-the-same commit message we can contain information
about what was changed.
Tests updated to support both old and new format (simple/rich ?).
