### PR TITLE
check mkdir returned err

### DIFF
--- a/bugapp/Create.go
+++ b/bugapp/Create.go
@@ -61,7 +61,11 @@ func Create(Args ArgumentList) {
 
 	var mode os.FileMode
 	mode = 0775
-	os.Mkdir(string(dir), mode)
+	err := os.Mkdir(string(dir), mode)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\n%s error: mkdir\n", os.Args[0])
+		log.Fatal(err)
+	}
 
 	if noDesc {
 		txt := []byte("")


### PR DESCRIPTION
    closes #16
This works great. I think a better implementation is to make
Directory.go:GetRootDir() return empty if the issues directory is missing in
BOTH the non PMIT and PMIT cases. However several tests depend on the bad
behavior and it would require some more refactoring of code and tests which can
be done separately.